### PR TITLE
Create minimal single-page Django setup

### DIFF
--- a/config/asgi.py
+++ b/config/asgi.py
@@ -1,0 +1,6 @@
+import os
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+application = get_asgi_application()

--- a/config/settings.py
+++ b/config/settings.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+SECRET_KEY = "development-secret-key"
+DEBUG = True
+ALLOWED_HOSTS: list[str] = []
+
+INSTALLED_APPS = [
+    "django.contrib.staticfiles",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+]
+
+ROOT_URLCONF = "config.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR / "templates"],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+            ],
+        },
+    },
+]
+
+WSGI_APPLICATION = "config.wsgi.application"
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
+    }
+}
+
+LANGUAGE_CODE = "en-us"
+TIME_ZONE = "UTC"
+USE_I18N = True
+USE_TZ = True
+
+STATIC_URL = "static/"
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from django.views.generic import TemplateView
+
+urlpatterns = [
+    path("", TemplateView.as_view(template_name="index.html"), name="home"),
+]

--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -1,0 +1,6 @@
+import os
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+application = get_wsgi_application()

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+import os
+import sys
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Minimal Django Page</title>
+  </head>
+  <body>
+    <main>
+      <h1>Hello, Django!</h1>
+      <p>This page comes from a single template file.</p>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a minimal Django project configuration pointing at a single template
- render the root URL with TemplateView to serve the educational one-page example

## Testing
- python manage.py check *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68e3d70f00e4832baf70796a463bbab1