### PR TITLE
Teach through commented Django blog example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
-# new_django
-simple django project
+# Educational Django Blog
+
+This project demonstrates the essential steps for building a basic blog with Django. Each file contains inline comments so you can follow the build from configuring settings through rendering posts on the homepage.
+
+## Getting Started
+
+1. **Install dependencies**
+   ```bash
+   pip install django
+   ```
+2. **Apply migrations** – creates the `Post` table.
+   ```bash
+   python manage.py migrate
+   ```
+3. **Create a superuser** – lets you log into the admin and add posts.
+   ```bash
+   python manage.py createsuperuser
+   ```
+4. **Run the development server**
+   ```bash
+   python manage.py runserver
+   ```
+5. **Add posts** via http://127.0.0.1:8000/admin/ and then view them on the homepage.
+
+Because the environment used to generate this project does not ship with Django, the automated checks may show import errors until you install the package locally.

--- a/blog/__init__.py
+++ b/blog/__init__.py
@@ -1,0 +1,1 @@
+# The blog app package is intentionally minimal so Django discovers it via INSTALLED_APPS.

--- a/blog/admin.py
+++ b/blog/admin.py
@@ -1,0 +1,13 @@
+from django.contrib import admin
+
+from .models import Post
+
+
+@admin.register(Post)
+class PostAdmin(admin.ModelAdmin):
+    """Expose the Post model in the Django admin for quick data entry."""
+
+    list_display = ("title", "published_at")
+    prepopulated_fields = {"slug": ("title",)}
+    search_fields = ("title", "body")
+    ordering = ("-published_at",)

--- a/blog/apps.py
+++ b/blog/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class BlogConfig(AppConfig):
+    """Application configuration that lets Django know about our blog app."""
+
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "blog"
+    verbose_name = "Educational Blog"

--- a/blog/migrations/0001_initial.py
+++ b/blog/migrations/0001_initial.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Initial database schema for the blog Post model."""
+
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name="Post",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("title", models.CharField(max_length=200)),
+                ("slug", models.SlugField(unique=True)),
+                ("body", models.TextField()),
+                ("published_at", models.DateTimeField()),
+            ],
+            options={"ordering": ["-published_at"]},
+        ),
+    ]

--- a/blog/migrations/__init__.py
+++ b/blog/migrations/__init__.py
@@ -1,0 +1,1 @@
+# Django looks for this file to treat the migrations folder as a Python package.

--- a/blog/models.py
+++ b/blog/models.py
@@ -1,0 +1,20 @@
+from django.db import models
+
+
+class Post(models.Model):
+    """A simple blog post with enough fields to mimic a real-world example."""
+
+    # A descriptive title shown in lists and as the page heading.
+    title = models.CharField(max_length=200)
+    # A slug is a URL-friendly identifier automatically generated from the title.
+    slug = models.SlugField(unique=True)
+    # The main article content.
+    body = models.TextField()
+    # Track when the post was published so we can order posts by recency.
+    published_at = models.DateTimeField()
+
+    class Meta:
+        ordering = ["-published_at"]
+
+    def __str__(self) -> str:
+        return self.title

--- a/blog/templates/blog/post_list.html
+++ b/blog/templates/blog/post_list.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block title %}Educational Blog — Home{% endblock %}
+
+{% block content %}
+  {# Step 5: Display the posts that the view passes in the context dictionary. #}
+  {% for post in posts %}
+    <article>
+      {# Step 5a: Use the title for the article heading. #}
+      <h2>{{ post.title }}</h2>
+      {# Step 5b: Format the publication date for readers. #}
+      <time datetime="{{ post.published_at|date:"c" }}">
+        Published on {{ post.published_at|date:"F j, Y" }}
+      </time>
+      {# Step 5c: Show the article body, preserving line breaks. #}
+      <p>{{ post.body|linebreaks }}</p>
+    </article>
+  {% empty %}
+    <p>No blog posts yet. Use the Django admin to add your first entry!</p>
+  {% endfor %}
+{% endblock %}

--- a/blog/urls.py
+++ b/blog/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from . import views
+
+app_name = "blog"
+
+urlpatterns = [
+    # The home page lists all posts, making it easy to extend with detail pages later.
+    path("", views.post_list, name="post_list"),
+]

--- a/blog/views.py
+++ b/blog/views.py
@@ -1,0 +1,12 @@
+from django.shortcuts import render
+
+from .models import Post
+
+
+def post_list(request):
+    """Return the list of blog posts to the template."""
+
+    # Query all posts (ordered by the model's Meta.ordering) to show on the homepage.
+    posts = Post.objects.all()
+    # Hand the post queryset to the template so it can loop over and display them.
+    return render(request, "blog/post_list.html", {"posts": posts})

--- a/config/asgi.py
+++ b/config/asgi.py
@@ -1,0 +1,6 @@
+import os
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+application = get_asgi_application()

--- a/config/settings.py
+++ b/config/settings.py
@@ -1,0 +1,78 @@
+"""Django settings for the educational blog project.
+
+Each section includes a short note about why it matters when building a blog.
+"""
+
+from pathlib import Path
+
+# Step 1: Calculate the base directory so the rest of the settings can find files.
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+# Step 2: Set debugging options and security placeholders.
+SECRET_KEY = "development-secret-key"
+DEBUG = True
+ALLOWED_HOSTS: list[str] = []
+
+# Step 3: Register Django's core apps along with our custom "blog" app.
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "blog",
+]
+
+# Step 4: Enable the middleware that powers sessions, messages, and security.
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+
+# Step 5: Point Django at the root URL configuration module.
+ROOT_URLCONF = "config.urls"
+
+# Step 6: Configure template discovery so Django finds ``templates/`` and app templates.
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR / "templates"],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    },
+]
+
+# Step 7: Allow Django to serve the project via WSGI-compatible servers.
+WSGI_APPLICATION = "config.wsgi.application"
+
+# Step 8: Use SQLite for a lightweight development database.
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
+    }
+}
+
+# Step 9: Localisation defaults.
+LANGUAGE_CODE = "en-us"
+TIME_ZONE = "UTC"
+USE_I18N = True
+USE_TZ = True
+
+# Step 10: Static file configuration for CSS/JS/images.
+STATIC_URL = "static/"
+
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,0 +1,11 @@
+"""Route HTTP requests to views for the educational blog."""
+
+from django.contrib import admin
+from django.urls import include, path
+
+urlpatterns = [
+    # Step 11: Add the Django admin so you can manage blog posts via the browser.
+    path("admin/", admin.site.urls),
+    # Step 12: Delegate root URL handling to the blog app's URL configuration.
+    path("", include("blog.urls")),
+]

--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -1,0 +1,6 @@
+import os
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+application = get_wsgi_application()

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+import os
+import sys
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>{% block title %}Educational Blog{% endblock %}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        margin: 0;
+        background: #f6f6f9;
+      }
+      header {
+        background: #283044;
+        color: #fff;
+        padding: 1.5rem;
+      }
+      main {
+        margin: 2rem auto;
+        width: min(55rem, 90vw);
+      }
+      article {
+        background: #fff;
+        border-radius: 0.5rem;
+        box-shadow: 0 0.75rem 2rem rgba(15, 23, 42, 0.1);
+        padding: 2rem;
+        margin-bottom: 1.5rem;
+      }
+      time {
+        color: #475569;
+        font-size: 0.875rem;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Educational Django Blog</h1>
+      <p>Use the inline comments to follow each step of the build.</p>
+    </header>
+    <main>
+      {% block content %}{% endblock %}
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- replace the single template view with a conventional blog app wired through settings and URLs
- add a Post model, admin registration, and migrations so learners can create entries
- create commented templates and README instructions that walk through each step of building the page

## Testing
- python manage.py check *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68e3d70f00e4832baf70796a463bbab1